### PR TITLE
Bump versions of rode, rode-ui, and grafeas-elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ For local access to Jenkins and Harbor through the created ingress, new entries 
 sudo vi /etc/hosts
 ```
 
-Copy and paste the two lines below to your /etc/hosts file.
+Copy and paste the lines below to your /etc/hosts file.
 ```
 127.0.0.1 harbor.localhost
 127.0.0.1 jenkins.localhost
+127.0.0.1 rode-ui.localhost
 ```
 ---
 Additionally, a rewrite may need to be added to your clusters DNS server to send Harbor traffic through the nginx controller. Automation is in place to update the CoreDNS configmap to include this rewrite, but in the event of a failed image deployment to Harbor inside the cluster, you may look to add the rewrite show below in the data block. (If your cluster is

--- a/tf/k8s/terragrunt.hcl
+++ b/tf/k8s/terragrunt.hcl
@@ -13,5 +13,5 @@ inputs = {
   enable_nginx    = true
   enable_jenkins  = true
   rode_ui_host    = "rode-ui.localhost"
-  rode_ui_version = "v0.1.1"
+  rode_ui_version = "v0.2.0"
 }

--- a/tf/modules/grafeas/main.tf
+++ b/tf/modules/grafeas/main.tf
@@ -9,7 +9,7 @@ resource "helm_release" "grafeas" {
   namespace  = kubernetes_namespace.grafeas.metadata[0].name
   chart      = "grafeas-elasticsearch"
   repository = "https://rode.github.io/charts"
-  version    = "0.0.6"
+  version    = "0.2.0"
   wait       = true
 
   values = [

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -9,7 +9,7 @@ resource "helm_release" "rode" {
   namespace  = kubernetes_namespace.rode.metadata[0].name
   chart      = "rode"
   repository = "https://rode.github.io/charts"
-  version    = "0.1.0"
+  version    = "0.1.2"
   wait       = true
 
   values = [
@@ -86,7 +86,7 @@ resource "helm_release" "rode_ui" {
   namespace  = kubernetes_namespace.rode.metadata[0].name
   chart      = "rode-ui"
   repository = "https://rode.github.io/charts"
-  version    = "0.1.0"
+  version    = "0.2.0"
   wait       = true
 
   values = [

--- a/tf/modules/rode/rode-values.yaml.tpl
+++ b/tf/modules/rode/rode-values.yaml.tpl
@@ -13,4 +13,4 @@ elasticsearch:
 debug: true
 
 image:
-  tag: "v0.1.0"
+  tag: "v0.1.1"


### PR DESCRIPTION
Pulls in the latest releases of the above, including their Helm charts. 