### PR TITLE
Upgrade Jenkins chart and plugins

### DIFF
--- a/tf/modules/jenkins/main.tf
+++ b/tf/modules/jenkins/main.tf
@@ -31,8 +31,8 @@ resource "kubernetes_secret" "jenkins_docker_config" {
 locals {
   jenkins_plugins = [
     "job-dsl:1.77",
-    "kubernetes-credentials-provider:0.15",
-    "sonar:2.12"
+    "kubernetes-credentials-provider:0.17",
+    "sonar:2.13"
   ]
 }
 
@@ -40,11 +40,11 @@ resource "helm_release" "jenkins" {
   chart      = "jenkins"
   name       = "jenkins"
   repository = "https://charts.jenkins.io"
-  version    = "2.13.1"
+  version    = "3.3.0"
   namespace  = kubernetes_namespace.jenkins.metadata[0].name
 
   set {
-    name  = "master.additionalPlugins"
+    name  = "controller.additionalPlugins"
     value = "{${join(",", local.jenkins_plugins)}}"
   }
 

--- a/tf/modules/jenkins/values.yaml.tpl
+++ b/tf/modules/jenkins/values.yaml.tpl
@@ -1,4 +1,4 @@
-master:
+controller:
    ingress:
        enabled: true
        apiVersion: "extensions/v1beta1"


### PR DESCRIPTION
Jenkins was failing to start with:

```
2021-03-29 20:47:10.356+0000 [id=26]	SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed Loading plugin Jenkins Git client plugin v3.7.0 (git-client)
java.io.IOException: Failed to load: Jenkins Git client plugin (3.7.0)
 - Update required: Configuration as Code Plugin (1.43) to be updated to 1.47 or higher
 - Failed to load: Credentials Plugin (2.3.15)
 ```

We decided to upgrade the chart, since it's currently a major version behind; we upgraded all plugins to their latest as well. 

![Screen Shot 2021-03-29 at 4 48 15 PM](https://user-images.githubusercontent.com/9082799/112904476-9eed6780-90ae-11eb-8c18-362a9d9aa984.png)


Here's the Helm chart [changelog](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/CHANGELOG.md), the biggest impact was updating `master` -> `controller`, as well as switching to a StatefulSet from a Deployment. 
