### PR TITLE
Add build collector to demo

### DIFF
--- a/app/Jenkinsfile
+++ b/app/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     --post-data='{
 	                    "repository": "https://github.com/rode/demo",
                         "artifacts": [
-                            "harbor.localhost/rode-demo/rode-demo-node-app@'$image'"
+                            "https://harbor.localhost/rode-demo/rode-demo-node-app@'$image'"
                         ],
                         "commit_id": "'$commit'"
                     }' \

--- a/app/Jenkinsfile
+++ b/app/Jenkinsfile
@@ -16,26 +16,20 @@ pipeline {
                     sh "executor -c app --skip-tls-verify --digest-file image -d harbor.localhost/rode-demo/rode-demo-node-app:${tag}"
                 }
                 container('git') {
-                    sh "cat image"
-                    sh '''wget -O- --post-data='{
+                    sh '''
+                    image=$(cat image | tr -d '[:space:]')
+                    commit=$(git rev-parse HEAD)
+                    wget -O- \
+                    --post-data='{
 	                    "repository": "https://github.com/rode/demo",
                         "artifacts": [
-                            "harbor.localhost/rode-demo/rode-demo-node-app@'$(cat image | tr -d '[:space:]')'"
+                            "harbor.localhost/rode-demo/rode-demo-node-app@'$image'"
                         ],
-                        "commit_id": "'$(git rev-parse HEAD)'"}' \
+                        "commit_id": "'$commit'"
+                    }' \
                     --header='Content-Type:application/json' \
                     'http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds'
                     '''
-                    // sh """wget --request POST \
-                    // --url http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds \
-                    // --header 'Content-Type: application/json' \
-                    // --data '{
-	                //     "repository": "https://github.com/rode/demo",
-                    //     "artifacts": [
-                    //         "harbor.localhost/rode-demo/rode-demo-node-app@sha256:8d4fa54b121be39290055ab79d95543ebcd4b13526026801dfb0697ff3b40700"
-                    //     ],
-                    //     "commit_id": "'$(git rev-parse HEAD)'"
-                    // }'"""
                 }
             }
         }

--- a/app/Jenkinsfile
+++ b/app/Jenkinsfile
@@ -17,7 +17,16 @@ pipeline {
                 }
                 container('git') {
                     sh "cat image"
-                    // sh """curl --request POST \
+                    sh """wget -O- --post-data='{
+	                    "repository": "https://github.com/rode/demo",
+                        "artifacts": [
+                            "harbor.localhost/rode-demo/rode-demo-node-app@'$(cat image | tr -d '[:space:]')'"
+                        ],
+                        "commit_id": "'$(git rev-parse HEAD)'"}' \
+                    --header='Content-Type:application/json' \
+                    'http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds'
+                    """
+                    // sh """wget --request POST \
                     // --url http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds \
                     // --header 'Content-Type: application/json' \
                     // --data '{

--- a/app/Jenkinsfile
+++ b/app/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
                 }
                 container('git') {
                     sh "cat image"
-                    sh """wget -O- --post-data='{
+                    sh '''wget -O- --post-data='{
 	                    "repository": "https://github.com/rode/demo",
                         "artifacts": [
                             "harbor.localhost/rode-demo/rode-demo-node-app@'$(cat image | tr -d '[:space:]')'"
@@ -25,7 +25,7 @@ pipeline {
                         "commit_id": "'$(git rev-parse HEAD)'"}' \
                     --header='Content-Type:application/json' \
                     'http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds'
-                    """
+                    '''
                     // sh """wget --request POST \
                     // --url http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds \
                     // --header 'Content-Type: application/json' \

--- a/app/Jenkinsfile
+++ b/app/Jenkinsfile
@@ -21,13 +21,13 @@ pipeline {
                     commit=$(git rev-parse HEAD)
                     wget -O- \
                     --post-data='{
-	                    "repository": "https://github.com/rode/demo",
+                        "repository": "https://github.com/rode/demo",
                         "artifacts": [
                             "https://harbor.localhost/rode-demo/rode-demo-node-app@'$image'"
                         ],
                         "commit_id": "'$commit'"
                     }' \
-                    --header='Content-Type:application/json' \
+                    --header='Content-Type: application/json' \
                     'http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds'
                     '''
                 }

--- a/app/Jenkinsfile
+++ b/app/Jenkinsfile
@@ -13,7 +13,20 @@ pipeline {
                     }
                 }
                 container('kaniko') {
-                    sh "executor -c app --skip-tls-verify -d harbor.localhost/rode-demo/rode-demo-node-app:${tag}"
+                    sh "executor -c app --skip-tls-verify --digest-file image -d harbor.localhost/rode-demo/rode-demo-node-app:${tag}"
+                }
+                container('git') {
+                    sh "cat image"
+                    // sh """curl --request POST \
+                    // --url http://rode-collector-build.rode-demo.svc.cluster.local:8083/v1alpha1/builds \
+                    // --header 'Content-Type: application/json' \
+                    // --data '{
+	                //     "repository": "https://github.com/rode/demo",
+                    //     "artifacts": [
+                    //         "harbor.localhost/rode-demo/rode-demo-node-app@sha256:8d4fa54b121be39290055ab79d95543ebcd4b13526026801dfb0697ff3b40700"
+                    //     ],
+                    //     "commit_id": "'$(git rev-parse HEAD)'"
+                    // }'"""
                 }
             }
         }

--- a/app/Jenkinsfile
+++ b/app/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
                     }
                 }
                 container('kaniko') {
-                    sh "executor -c app --skip-tls-verify -d harbor.localhost/library/rode-demo-node-app:${tag}"
+                    sh "executor -c app --skip-tls-verify -d harbor.localhost/rode-demo/rode-demo-node-app:${tag}"
                 }
             }
         }

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "1.13.3"
+      version = "2.0.0"
     }
 
     helm = {
       source  = "hashicorp/helm"
-      version = "2.0.1"
+      version = "2.0.3"
     }
 
     random = {

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -127,7 +127,7 @@ module "harbor_config" {
   source = "../modules/harbor-config"
 
   webhook_endpoint = "http://rode-collector-harbor.rode-demo.svc.cluster.local/webhook/event"
-  depends_on       = [
+  depends_on = [
     module.harbor
   ]
 }

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -18,7 +18,7 @@ terraform {
     }
     harbor = {
       source  = "liatrio/harbor"
-      version = "0.3.1"
+      version = "0.3.4"
     }
   }
 }

--- a/tf/modules/grafeas/main.tf
+++ b/tf/modules/grafeas/main.tf
@@ -14,7 +14,7 @@ resource "helm_release" "grafeas" {
 
   values = [
     templatefile("${path.module}/values.yaml.tpl", {
-      elasticsearch_url = "http://${var.elasticsearch_host}"
+      elasticsearch_url      = "http://${var.elasticsearch_host}"
       elasticsearch_username = var.elasticsearch_username
       elasticsearch_password = var.elasticsearch_host
     })

--- a/tf/modules/harbor-config/main.tf
+++ b/tf/modules/harbor-config/main.tf
@@ -1,14 +1,14 @@
 resource "harbor_project" "project" {
-  name = "rode-demo"
+  name      = "rode-demo"
   auto_scan = true
 }
 
 resource "harbor_webhook" "webhook" {
-  project_id = harbor_project.project.id
-  name = "Rode"
+  project_id  = harbor_project.project.id
+  name        = "Rode"
   event_types = ["PUSH_ARTIFACT", "SCANNING_COMPLETED", "SCANNING_FAILED"]
   target {
-    type = "http"
+    type    = "http"
     address = var.webhook_endpoint
   }
 }

--- a/tf/modules/harbor-config/versions.tf
+++ b/tf/modules/harbor-config/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     harbor = {
       source = "liatrio/harbor"
-      version = "0.3.1"
+      version = "0.3.4"
     }
   }
 }

--- a/tf/modules/harbor-config/versions.tf
+++ b/tf/modules/harbor-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
   required_providers {
     harbor = {
-      source = "liatrio/harbor"
+      source  = "liatrio/harbor"
       version = "0.3.4"
     }
   }

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -24,8 +24,8 @@ resource "kubernetes_ingress" "rode" {
   count = var.host == "" ? 0 : 1
 
   metadata {
-    namespace   = kubernetes_namespace.rode.metadata[0].name
-    name        = "rode"
+    namespace = kubernetes_namespace.rode.metadata[0].name
+    name      = "rode"
     annotations = {
       "nginx.ingress.kubernetes.io/backend-protocol" = "GRPC"
     }
@@ -94,6 +94,24 @@ resource "helm_release" "rode_ui" {
       namespace       = kubernetes_namespace.rode.metadata[0].name
       rode_ui_version = var.rode_ui_version
       rode_ui_host    = var.rode_ui_host
+    })
+  ]
+
+  depends_on = [
+    helm_release.rode
+  ]
+}
+
+resource "helm_release" "rode_collector_build" {
+  name      = "rode-collector-build"
+  namespace = kubernetes_namespace.rode.metadata[0].name
+  chart     = "/Users/brad/charts/charts/rode-collector-build"
+  version   = "0.1.0"
+  wait      = true
+
+  values = [
+    templatefile("${path.module}/rode-collector-build-values.yaml.tpl", {
+      namespace = kubernetes_namespace.rode.metadata[0].name
     })
   ]
 

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -103,11 +103,12 @@ resource "helm_release" "rode_ui" {
 }
 
 resource "helm_release" "rode_collector_build" {
-  name      = "rode-collector-build"
-  namespace = kubernetes_namespace.rode.metadata[0].name
-  chart     = "/Users/brad/charts/charts/rode-collector-build"
-  version   = "0.1.0"
-  wait      = true
+  name       = "rode-collector-build"
+  namespace  = kubernetes_namespace.rode.metadata[0].name
+  repository = "https://rode.github.io/charts"
+  chart      = "rode-collector-build"
+  version    = "0.1.0"
+  wait       = true
 
   values = [
     templatefile("${path.module}/rode-collector-build-values.yaml.tpl", {

--- a/tf/modules/rode/rode-collector-build-values.yaml.tpl
+++ b/tf/modules/rode/rode-collector-build-values.yaml.tpl
@@ -1,0 +1,5 @@
+rode:
+  host: rode.${namespace}.svc.cluster.local:50051
+  insecure: true
+
+debug: true


### PR DESCRIPTION
Also closes #14 by updating the Helm provider. `terragrunt run-all destroy` will still print a warning about the Helm uninstall messages, but should exit successfully:

```

Warning: Helm uninstall returned an information message

manifest-14
manifest-15
manifest-16



Destroy complete! Resources: 28 destroyed.
```

The demo should now push the app image to the `rode-demo` repository and trigger the creation of discovery and build occurrences. 