### PR TITLE
Bump Jenkins configuration as code plugin to 1.48

### DIFF
--- a/tf/modules/jenkins/agent.tf
+++ b/tf/modules/jenkins/agent.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_service_account" "jenkins_agent" {
   metadata {
     name      = "jenkins-agent"
-    namespace = var.namespace
+    namespace = kubernetes_namespace.jenkins.metadata[0].name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -23,7 +23,7 @@ resource "kubernetes_service_account" "jenkins_agent" {
 resource "kubernetes_role" "jenkins_agent_dev" {
   metadata {
     name      = "jenkins-agent"
-    namespace = "${var.deploy_namespace}-dev"
+    namespace = kubernetes_namespace.deploy_dev.metadata[0].name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -66,7 +66,7 @@ resource "kubernetes_role" "jenkins_agent_dev" {
 resource "kubernetes_role_binding" "jenkins_agent_dev" {
   metadata {
     name      = "jenkins-agent"
-    namespace = "${var.deploy_namespace}-dev"
+    namespace = kubernetes_namespace.deploy_dev.metadata[0].name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -98,7 +98,7 @@ resource "kubernetes_role_binding" "jenkins_agent_dev" {
 resource "kubernetes_role" "jenkins_agent_staging" {
   metadata {
     name      = "jenkins-agent"
-    namespace = "${var.deploy_namespace}-staging"
+    namespace = kubernetes_namespace.deploy_staging.metadata[0].name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -141,7 +141,7 @@ resource "kubernetes_role" "jenkins_agent_staging" {
 resource "kubernetes_role_binding" "jenkins_agent_staging" {
   metadata {
     name      = "jenkins-agent"
-    namespace = "${var.deploy_namespace}-staging"
+    namespace = kubernetes_namespace.deploy_staging.metadata[0].name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -173,7 +173,7 @@ resource "kubernetes_role_binding" "jenkins_agent_staging" {
 resource "kubernetes_role" "jenkins_agent_prod" {
   metadata {
     name      = "jenkins-agent"
-    namespace = "${var.deploy_namespace}-prod"
+    namespace = kubernetes_namespace.deploy_prod.metadata[0].name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -216,7 +216,7 @@ resource "kubernetes_role" "jenkins_agent_prod" {
 resource "kubernetes_role_binding" "jenkins_agent_prod" {
   metadata {
     name      = "jenkins-agent"
-    namespace = "${var.deploy_namespace}-prod"
+    namespace = kubernetes_namespace.deploy_prod.metadata[0].name
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"

--- a/tf/modules/jenkins/main.tf
+++ b/tf/modules/jenkins/main.tf
@@ -48,6 +48,11 @@ resource "kubernetes_secret" "jenkins_docker_config" {
 
 locals {
   jenkins_plugins = [
+    "configuration-as-code:1.48",
+    "kubernetes:1.29.2",
+    "workflow-aggregator:2.6",
+    "git:4.7.1",
+
     "job-dsl:1.77",
     "kubernetes-credentials-provider:0.17",
     "sonar:2.13"
@@ -62,7 +67,7 @@ resource "helm_release" "jenkins" {
   namespace  = kubernetes_namespace.jenkins.metadata[0].name
 
   set {
-    name  = "controller.additionalPlugins"
+    name  = "controller.installPlugins"
     value = "{${join(",", local.jenkins_plugins)}}"
   }
 


### PR DESCRIPTION
The casc plugin has a new release and through the magic of transitive dependencies that seems to have broken the Jenkins init container:

```
disable Setup Wizard
download plugins
Multiple plugin prerequisites not met:
Plugin kubernetes:1.29.2 depends transitively (via credentials:2.3.18) on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin workflow-aggregator:2.6 depends transitively (via credentials:2.3.18) on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin workflow-aggregator:2.6 depends transitively (via git-client:3.7.1) on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin git:4.6.0 depends directly on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin git:4.6.0 depends transitively (via credentials:2.3.18) on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin git:4.6.0 depends transitively (via git-client:3.7.1) on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin job-dsl:1.77 depends directly on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin kubernetes-credentials-provider:0.17 depends transitively (via credentials:2.3.18) on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47,
Plugin sonar:2.13 depends transitively (via credentials:2.3.18) on configuration-as-code:1.48, but there is an older version defined on the top level - configuration-as-code:1.47
```

The Helm chart specifies the version of the casc plugin through the `controller.installPlugins` field, so we have to include the other plugins in the list; however, I didn't change those versions. 