### PR TITLE
add environment variables to jenkins for harbor host and rode namespace

### DIFF
--- a/tf/environments/aws/prod/terragrunt.hcl
+++ b/tf/environments/aws/prod/terragrunt.hcl
@@ -40,6 +40,6 @@ inputs = {
   rode_ui_host           = "rode-ui.rode.lead.prod.liatr.io"
   update_coredns         = "false"
   rode_ui_version        = "v0.8.0"
-  rode_version           = "v0.6.0"
+  rode_version           = "v0.6.1"
   grafeas_version        = "v0.6.4"
 }

--- a/tf/environments/aws/sandbox/terragrunt.hcl
+++ b/tf/environments/aws/sandbox/terragrunt.hcl
@@ -40,6 +40,6 @@ inputs = {
   rode_ui_host           = "rode-ui.rode.lead.sandbox.liatr.io"
   update_coredns         = "false"
   rode_ui_version        = "v0.8.0"
-  rode_version           = "v0.6.0"
+  rode_version           = "v0.6.1"
   grafeas_version        = "v0.6.4"
 }

--- a/tf/environments/local/terragrunt.hcl
+++ b/tf/environments/local/terragrunt.hcl
@@ -26,7 +26,7 @@ inputs = {
   enable_jenkins  = true
   rode_ui_host    = "rode-ui.localhost"
   rode_ui_version = "v0.8.0"
-  rode_version    = "v0.6.0"
+  rode_version    = "v0.6.1"
   grafeas_version = "v0.6.4"
   ingress_name    = "nginx"
 }

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -121,6 +121,7 @@ module "jenkins" {
   jenkins_host     = var.jenkins_host
   harbor_namespace = module.harbor.namespace
   harbor_host      = var.harbor_host
+  rode_namespace   = var.rode_namespace
   namespace        = var.jenkins_namespace
   ingress_class    = var.ingress_class
   deploy_namespace = var.deploy_namespace

--- a/tf/modules/jenkins/main.tf
+++ b/tf/modules/jenkins/main.tf
@@ -98,7 +98,7 @@ resource "kubernetes_config_map" "jcasc_pipelines" {
   metadata {
     name      = "${helm_release.jenkins.name}-jcasc-pipelines"
     namespace = kubernetes_namespace.jenkins.metadata[0].name
-    labels = {
+    labels    = {
       "${helm_release.jenkins.name}-jenkins-config" = "true"
     }
   }
@@ -108,6 +108,8 @@ resource "kubernetes_config_map" "jcasc_pipelines" {
       pipelineOrg           = "rode"
       pipelineRepo          = "demo-app"
       credentialsSecretName = ""
+      harbor_host           = var.harbor_host
+      rode_namespace        = var.rode_namespace
     })
   }
 }

--- a/tf/modules/jenkins/pipelines.yaml.tpl
+++ b/tf/modules/jenkins/pipelines.yaml.tpl
@@ -33,3 +33,11 @@ unclassified:
       triggers:
         skipScmCause: false
         skipUpstreamCause: false
+jenkins:
+  globalNodeProperties:
+    - envVars:
+        env:
+          - key: "HARBOR_HOST"
+            value: "${harbor_host}"
+          - key: "RODE_NAMESPACE"
+            value: "${rode_namespace}"

--- a/tf/modules/jenkins/variables.tf
+++ b/tf/modules/jenkins/variables.tf
@@ -1,6 +1,7 @@
 variable "harbor_namespace" {}
 variable "harbor_host" {}
 variable "jenkins_host" {}
+variable "rode_namespace" {}
 variable "namespace" {}
 variable "ingress_class" {
   default = ""


### PR DESCRIPTION
this will allow the `Jenkinsfile` in the demo-app repo to use these variables instead of hardcoding them to our deployed prod environments.

also bumps rode to `v0.6.1`