### PR TITLE
Add image pull secrets for Harbor

### DIFF
--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -120,6 +120,15 @@ module "coredns" {
   ]
 }
 
+module "demo_app_setup" {
+  source = "../modules/demo-app-setup"
+
+  environments     = var.environments
+  harbor_host      = var.harbor_host
+  harbor_namespace = var.harbor_namespace
+  deploy_namespace = var.deploy_namespace
+}
+
 module "jenkins" {
   count  = var.enable_jenkins ? 1 : 0
   source = "../modules/jenkins"
@@ -132,10 +141,12 @@ module "jenkins" {
   namespace_annotations = var.namespace_annotations
   ingress_class         = var.ingress_class
   deploy_namespace      = var.deploy_namespace
+  environments          = var.environments
 
   depends_on = [
     module.nginx,
-    module.harbor
+    module.harbor,
+    module.demo_app_setup
   ]
 }
 

--- a/tf/k8s/variables.tf
+++ b/tf/k8s/variables.tf
@@ -76,3 +76,8 @@ variable "namespace_annotations" {
   type    = map(string)
   default = {}
 }
+
+variable "environments" {
+  type    = set(string)
+  default = ["dev", "staging", "prod"]
+}

--- a/tf/modules/demo-app-setup/app.tf
+++ b/tf/modules/demo-app-setup/app.tf
@@ -1,0 +1,30 @@
+resource "kubernetes_namespace" "deploy_namespace" {
+  for_each = var.environments
+  metadata {
+    name = "${var.deploy_namespace}-${each.key}"
+  }
+}
+
+data "kubernetes_secret" "harbor" {
+  metadata {
+    name      = var.harbor_secret
+    namespace = var.harbor_namespace
+  }
+}
+
+resource "kubernetes_secret" "image_pull_secret" {
+  for_each = var.environments
+  metadata {
+    name      = "harbor"
+    namespace = kubernetes_namespace.deploy_namespace[each.key].metadata[0].name
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+  data = {
+    ".dockerconfigjson" = templatefile("${path.module}/dockercfg.tpl", {
+      email = "admin@liatr.io"
+      url   = "https://${var.harbor_host}"
+      auth  = base64encode("admin:${data.kubernetes_secret.harbor.data.HARBOR_ADMIN_PASSWORD}")
+    })
+  }
+}

--- a/tf/modules/demo-app-setup/dockercfg.tpl
+++ b/tf/modules/demo-app-setup/dockercfg.tpl
@@ -1,0 +1,8 @@
+{
+  "auths": {
+    "${url}": {
+      "email": "${email}",
+      "auth": "${auth}"
+    }
+  }
+}

--- a/tf/modules/demo-app-setup/variables.tf
+++ b/tf/modules/demo-app-setup/variables.tf
@@ -1,0 +1,21 @@
+variable "environments" {
+  type    = set(string)
+  default = []
+}
+
+variable "deploy_namespace" {
+  type = string
+}
+
+variable "harbor_host" {
+  type = string
+}
+
+variable "harbor_namespace" {
+  type = string
+}
+
+variable "harbor_secret" {
+  type    = string
+  default = "harbor-harbor-core"
+}

--- a/tf/modules/jenkins/agent.tf
+++ b/tf/modules/jenkins/agent.tf
@@ -20,10 +20,11 @@ resource "kubernetes_service_account" "jenkins_agent" {
 }
 
 // Add role permissions for Jenkins Agents
-resource "kubernetes_role" "jenkins_agent_dev" {
+resource "kubernetes_role" "jenkins_agent" {
+  for_each = var.environments
   metadata {
     name      = "jenkins-agent"
-    namespace = kubernetes_namespace.deploy_dev.metadata[0].name
+    namespace = "${var.deploy_namespace}-${each.key}"
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -63,10 +64,11 @@ resource "kubernetes_role" "jenkins_agent_dev" {
 }
 
 // Bind Kubernetes secrets role to Jenkins service account
-resource "kubernetes_role_binding" "jenkins_agent_dev" {
+resource "kubernetes_role_binding" "jenkins_agent" {
+  for_each = var.environments
   metadata {
     name      = "jenkins-agent"
-    namespace = kubernetes_namespace.deploy_dev.metadata[0].name
+    namespace = "${var.deploy_namespace}-${each.key}"
 
     labels = {
       "app.kubernetes.io/name"       = "jenkins"
@@ -84,157 +86,7 @@ resource "kubernetes_role_binding" "jenkins_agent_dev" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role.jenkins_agent_dev.metadata[0].name
-  }
-
-  subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account.jenkins_agent.metadata[0].name
-    namespace = var.namespace
-  }
-}
-
-// Add role permissions for Jenkins Agents
-resource "kubernetes_role" "jenkins_agent_staging" {
-  metadata {
-    name      = "jenkins-agent"
-    namespace = kubernetes_namespace.deploy_staging.metadata[0].name
-
-    labels = {
-      "app.kubernetes.io/name"       = "jenkins"
-      "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
-      "app.kubernetes.io/managed-by" = "Terraform"
-    }
-
-    annotations = {
-      description = "Permission required for Jenkins agents"
-      source-repo = "https://github.com/rode/demo"
-    }
-  }
-
-  rule {
-    api_groups = [""]
-    resources  = ["services", "configmaps", "secrets", "namespaces", "serviceaccounts"]
-    verbs      = ["*"]
-  }
-
-  rule {
-    api_groups = ["apps"]
-    resources  = ["deployments", "statefulsets", "replicasets"]
-    verbs      = ["*"]
-  }
-  rule {
-    api_groups = ["networking.k8s.io"]
-    resources  = ["ingresses"]
-    verbs      = ["*"]
-  }
-  rule {
-    api_groups = ["policy"]
-    resources  = ["poddisruptionbudgets"]
-    verbs      = ["*"]
-  }
-
-}
-
-// Bind Kubernetes secrets role to Jenkins service account
-resource "kubernetes_role_binding" "jenkins_agent_staging" {
-  metadata {
-    name      = "jenkins-agent"
-    namespace = kubernetes_namespace.deploy_staging.metadata[0].name
-
-    labels = {
-      "app.kubernetes.io/name"       = "jenkins"
-      "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
-      "app.kubernetes.io/managed-by" = "Terraform"
-    }
-
-    annotations = {
-      description = "Permission required for Jenkins Agents"
-      source-repo = "https://github.com/rode/demo"
-    }
-  }
-
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "Role"
-    name      = kubernetes_role.jenkins_agent_staging.metadata[0].name
-  }
-
-  subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account.jenkins_agent.metadata[0].name
-    namespace = var.namespace
-  }
-}
-
-// Add role permissions for Jenkins Agents
-resource "kubernetes_role" "jenkins_agent_prod" {
-  metadata {
-    name      = "jenkins-agent"
-    namespace = kubernetes_namespace.deploy_prod.metadata[0].name
-
-    labels = {
-      "app.kubernetes.io/name"       = "jenkins"
-      "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
-      "app.kubernetes.io/managed-by" = "Terraform"
-    }
-
-    annotations = {
-      description = "Permission required for Jenkins agents"
-      source-repo = "https://github.com/rode/demo"
-    }
-  }
-
-  rule {
-    api_groups = [""]
-    resources  = ["services", "configmaps", "secrets", "namespaces", "serviceaccounts"]
-    verbs      = ["*"]
-  }
-
-  rule {
-    api_groups = ["apps"]
-    resources  = ["deployments", "statefulsets", "replicasets"]
-    verbs      = ["*"]
-  }
-  rule {
-    api_groups = ["networking.k8s.io"]
-    resources  = ["ingresses"]
-    verbs      = ["*"]
-  }
-  rule {
-    api_groups = ["policy"]
-    resources  = ["poddisruptionbudgets"]
-    verbs      = ["*"]
-  }
-
-}
-
-// Bind Kubernetes secrets role to Jenkins service account
-resource "kubernetes_role_binding" "jenkins_agent_prod" {
-  metadata {
-    name      = "jenkins-agent"
-    namespace = kubernetes_namespace.deploy_prod.metadata[0].name
-
-    labels = {
-      "app.kubernetes.io/name"       = "jenkins"
-      "app.kubernetes.io/instance"   = "jenkins"
-      "app.kubernetes.io/component"  = "jenkins-master"
-      "app.kubernetes.io/managed-by" = "Terraform"
-    }
-
-    annotations = {
-      description = "Permission required for Jenkins Agents"
-      source-repo = "https://github.com/rode/demo"
-    }
-  }
-
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "Role"
-    name      = kubernetes_role.jenkins_agent_prod.metadata[0].name
+    name      = kubernetes_role.jenkins_agent[each.key].metadata[0].name
   }
 
   subject {

--- a/tf/modules/jenkins/main.tf
+++ b/tf/modules/jenkins/main.tf
@@ -5,24 +5,6 @@ resource "kubernetes_namespace" "jenkins" {
   }
 }
 
-resource "kubernetes_namespace" "deploy_dev" {
-  metadata {
-    name = "${var.deploy_namespace}-dev"
-  }
-}
-
-resource "kubernetes_namespace" "deploy_staging" {
-  metadata {
-    name = "${var.deploy_namespace}-staging"
-  }
-}
-
-resource "kubernetes_namespace" "deploy_prod" {
-  metadata {
-    name = "${var.deploy_namespace}-prod"
-  }
-}
-
 data "kubernetes_secret" "harbor_auth" {
   metadata {
     name      = "harbor-harbor-core"

--- a/tf/modules/jenkins/variables.tf
+++ b/tf/modules/jenkins/variables.tf
@@ -11,3 +11,8 @@ variable "ingress_class" {
   default = ""
 }
 variable "deploy_namespace" {}
+
+variable "environments" {
+  type    = set(string)
+  default = []
+}


### PR DESCRIPTION
This PR adds a new module `demo-app-setup` that creates the namespaces for the demo-app (`dev`/`staging`/`prod`) along with an image pull secret for Harbor in each namespace.

I decided to split this out of the `jenkins` module so that any alternative CI we add to the demo (e.g., GitHub Actions) still has the right configuration even if `enable_jenkins` is false. 

This will destroy and recreate the demo-app namespaces, unless we want to do some state surgery. 

I went ahead and applied this in sandbox and was able to run an instance of the demo-app successfully:
```
kubectl -n rode-demo-app-prod get po 
NAME       READY   STATUS    RESTARTS   AGE
demo-app   1/1     Running   0          19s
```