### PR TITLE
Configure AzureAD authentication

### DIFF
--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -28,6 +28,11 @@ terraform {
       source  = "mrparkers/keycloak"
       version = "3.2.0-rc.0"
     }
+
+    azuread = {
+      source = "hashicorp/azuread"
+      version = "1.6.0"
+    }
   }
 }
 
@@ -64,6 +69,10 @@ provider "sonarqube" {
   user              = var.enable_sonarqube ? module.sonarqube[0].sonarqube_username : ""
   pass              = var.enable_sonarqube ? module.sonarqube[0].sonarqube_password : ""
   installed_version = "8.5"
+}
+
+provider "azuread" {
+  tenant_id       = var.azure_tenant_id
 }
 
 module "elasticsearch" {
@@ -218,5 +227,12 @@ module "keycloak" {
   namespace_annotations = var.namespace_annotations
   ingress_class         = var.ingress_class
   keycloak_host         = var.keycloak_host
+  rode_ui_host          = var.rode_ui_host
+}
+
+module "azuread" {
+  count  = var.enable_azuread ? 1 : 0
+  source = "../modules/azuread"
+
   rode_ui_host          = var.rode_ui_host
 }

--- a/tf/k8s/variables.tf
+++ b/tf/k8s/variables.tf
@@ -108,3 +108,11 @@ variable "enable_keycloak" {
 variable "keycloak_tls_insecure_skip_verify" {
   default = false
 }
+
+variable "enable_azuread" {
+  default = false
+}
+
+variable "azure_tenant_id" {
+  default = ""
+}

--- a/tf/modules/azuread/main.tf
+++ b/tf/modules/azuread/main.tf
@@ -1,0 +1,92 @@
+locals {
+  roles = toset([
+    "Collector",
+    "Enforcer",
+    "ApplicationDeveloper",
+    "PolicyDeveloper",
+    "PolicyAdministrator",
+    "Administrator"
+  ])
+}
+
+data "azuread_client_config" "current" {}
+
+data "azuread_service_principal" "ms_graph" {
+  display_name = "Microsoft Graph"
+}
+
+resource "random_password" "client_secret" {
+  length = 12
+}
+
+resource "random_uuid" "scope_id" {}
+
+resource "azuread_application" "rode" {
+  display_name     = "rode"
+  sign_in_audience = "AzureADMyOrg"
+  identifier_uris  = ["api://rode"]
+
+  web {
+    homepage_url  = "https://${var.rode_ui_host}"
+    redirect_uris = [
+      "http://localhost:3000/",
+      "http://localhost:3000/callback",
+      "https://${var.rode_ui_host}/",
+      "https://${var.rode_ui_host}/callback",
+    ]
+
+    implicit_grant {
+      access_token_issuance_enabled = false
+    }
+  }
+
+  api {
+    oauth2_permission_scope {
+      id                         = random_uuid.scope_id.result
+      enabled                    = true
+      type                       = "User"
+      value                      = "rode"
+      admin_consent_description  = "Access Rode application"
+      admin_consent_display_name = "Access Rode application"
+      user_consent_description   = "Access Rode application"
+      user_consent_display_name  = "Access Rode application"
+    }
+  }
+
+  dynamic "app_role" {
+    for_each = local.roles
+    content {
+      allowed_member_types = [
+        "User"]
+      enabled              = true
+      description          = app_role.value
+      display_name         = app_role.value
+    }
+  }
+
+  prevent_duplicate_names        = true
+  fallback_public_client_enabled = false
+
+  owners = [
+    data.azuread_client_config.current.object_id,
+  ]
+
+  provisioner "local-exec" {
+    command = <<EOT
+az rest -m patch -u "https://graph.microsoft.com/beta/applications/${azuread_application.rode.id}" \
+  -b '{"api": {"requestedAccessTokenVersion": 2}, "web": {"implicitGrantSettings": {"enableIdTokenIssuance":false}}}' \
+  --headers "Content-Type=application/json"
+EOT
+  }
+}
+
+resource "azuread_service_principal" "rode" {
+  app_role_assignment_required = true
+  application_id               = azuread_application.rode.application_id
+}
+
+resource "azuread_application_password" "client_secret" {
+  application_object_id = azuread_application.rode.object_id
+  value                 = random_password.client_secret.result
+  end_date_relative     = format("%dh", 5 * 365 * 24)
+}

--- a/tf/modules/azuread/outputs.tf
+++ b/tf/modules/azuread/outputs.tf
@@ -1,0 +1,16 @@
+output "rode_client_id" {
+  value = azuread_application.rode.application_id
+}
+
+output "rode_client_secret" {
+  sensitive = true
+  value     = azuread_application_password.client_secret.value
+}
+
+output "rode_app_object_id" {
+  value = azuread_application.rode.object_id
+}
+
+output "rode_sp_object_id" {
+  value = azuread_service_principal.rode.object_id
+}

--- a/tf/modules/azuread/outputs.tf
+++ b/tf/modules/azuread/outputs.tf
@@ -1,16 +1,8 @@
-output "rode_client_id" {
-  value = azuread_application.rode.application_id
+output "rode_ui_client_id" {
+  value = azuread_application.rode_ui.application_id
 }
 
-output "rode_client_secret" {
+output "rode_ui_client_secret" {
   sensitive = true
   value     = azuread_application_password.client_secret.value
-}
-
-output "rode_app_object_id" {
-  value = azuread_application.rode.object_id
-}
-
-output "rode_sp_object_id" {
-  value = azuread_service_principal.rode.object_id
 }

--- a/tf/modules/azuread/variables.tf
+++ b/tf/modules/azuread/variables.tf
@@ -1,0 +1,3 @@
+variable "rode_ui_host" {
+  type = string
+}


### PR DESCRIPTION
This is a sample for configuring AzureAD with Rode. 

## Notes

- There are v1 and v2 endpoints in AzureAD, but also a v1 and v2 of the token format. The version of the token format doesn't correspond at all to the endpoint version -- with the default app registration setup you'll get a v1 token from the v2 endpoint. We require the v2 token format so that the `aud` claim is the Rode client id (with the v1 format the `aud` claim is the identifier uri).  The token version can't be set through Terraform until the next major version of the provider is released.
- It seems like we have to define separate app registrations as defining a single client causes problems with getting the roles in the token. AzureAD strictly enforces that an access token is for a single API (or "resource") that is distinct from the client itself. So a client only gets its app roles in the id token and not the access token. You can define the client app as its own required resource; however, that doesn't lend itself well to Terraform and seemed to break token refresh. 
- The implicit flow is still enabled, but it will only grant id tokens. This is another limitation in the provider that should be fixed in the next major release.
- Role values cannot contain spaces, so I had to update those in Rode locally. I'll open a PR for it.

## Manual Configuration

There a few manual steps outside of Terraform that don't seem possible to automate:

- add users (or groups) to the Rode and Rode UI enterprise applications
- assign users (or groups) app roles in the Rode enterprise application

## App  Configuration

### Rode
To run Rode with AzureAD:

```
go run main.go \
  --grafeas-host=grafeas-server.rode-demo-grafeas.svc.cluster.local:8080 \
  --elasticsearch-host=http://elasticsearch-master.rode-demo-elasticsearch.svc.cluster.local:9200 \
  --debug \
  --opa-host=http://rode-opa.rode-demo.svc.cluster.local:8181 \
  --oidc-issuer=https://login.microsoftonline.com/${TENANT_ID}/v2.0 \
  --oidc-role-claim-path=roles
```

The value of `--oidc-role-claim-path` is the default and could be omitted, but it's here for completeness. 

### Rode UI

The important thing to note is the value of `OIDC_SCOPE`,  it must include whatever scope was defined on the Rode app registration or the app roles won't be in the token. It should include the `offline_access` scope, without it the token set won't include a refresh token. 

```
OIDC_CLIENT_ID=foo
OIDC_CLIENT_SECRET=bar
OIDC_ENABLED=true 
OIDC_SCOPE='openid profile email offline_access api://rode/rode'
OIDC_ISSUER_URL=https://login.microsoftonline.com/${TENANT_ID}/v2.0
APP_SECRET=baz
```
