### PR TITLE
Remove spaces from role names

### DIFF
--- a/tf/modules/keycloak/roles.tf
+++ b/tf/modules/keycloak/roles.tf
@@ -17,7 +17,7 @@ resource "keycloak_role" "demo_role" {
   for_each  = local.roles
   realm_id  = keycloak_realm.rode_demo.id
   client_id = keycloak_openid_client.rode.id
-  name      = each.key
+  name      = replace(each.key, " ", "")
 }
 
 resource "keycloak_group" "demo_group" {


### PR DESCRIPTION
This came out of #67, as role values in Azure can't contain spaces. This PR strips spaces from the role values when configuring Keycloak, so that Rode doesn't have to transform role values or maintain a map for different providers. 