### PR TITLE
support full authentication / authorization configuration with keycloak

### DIFF
--- a/tf/environments/aws/prod/terragrunt.hcl
+++ b/tf/environments/aws/prod/terragrunt.hcl
@@ -52,12 +52,12 @@ inputs = {
   update_coredns         = false
 
   rode_ui_version             = "v0.17.3"
-  rode_version                = "v0.14.4"
+  rode_version                = "v0.14.5"
   grafeas_version             = "v0.8.2"
   build_collector_version     = "v0.3.3"
   harbor_collector_version    = "v0.2.1"
   tfsec_collector_version     = "v0.1.1"
-  sonarqube_collector_version = "v0.2.0"
+  sonarqube_collector_version = "v0.2.1"
 
   namespace_annotations = {
     "downscaler/exclude" = "true"

--- a/tf/environments/aws/prod/terragrunt.hcl
+++ b/tf/environments/aws/prod/terragrunt.hcl
@@ -51,13 +51,13 @@ inputs = {
   tfsec_collector_host   = "tfsec-collector.rode.lead.prod.liatr.io"
   update_coredns         = false
 
-  rode_ui_version             = "v0.12.0"
-  rode_version                = "v0.9.2"
+  rode_ui_version             = "v0.17.3"
+  rode_version                = "v0.14.4"
   grafeas_version             = "v0.8.2"
-  build_collector_version     = "v0.3.0"
-  harbor_collector_version    = "v0.1.0"
-  tfsec_collector_version     = "v0.1.0"
-  sonarqube_collector_version = "v0.1.0"
+  build_collector_version     = "v0.3.3"
+  harbor_collector_version    = "v0.2.1"
+  tfsec_collector_version     = "v0.1.1"
+  sonarqube_collector_version = "v0.2.0"
 
   namespace_annotations = {
     "downscaler/exclude" = "true"

--- a/tf/environments/aws/sandbox/terragrunt.hcl
+++ b/tf/environments/aws/sandbox/terragrunt.hcl
@@ -51,11 +51,11 @@ inputs = {
   tfsec_collector_host   = "tfsec-collector.rode.lead.sandbox.liatr.io"
   update_coredns         = false
 
-  rode_ui_version             = "v0.13.0"
-  rode_version                = "v0.10.0"
+  rode_ui_version             = "v0.17.3"
+  rode_version                = "v0.14.4"
   grafeas_version             = "v0.8.2"
-  build_collector_version     = "v0.3.0"
-  harbor_collector_version    = "v0.1.0"
-  tfsec_collector_version     = "v0.1.0"
-  sonarqube_collector_version = "v0.1.0"
+  build_collector_version     = "v0.3.3"
+  harbor_collector_version    = "v0.2.1"
+  tfsec_collector_version     = "v0.1.1"
+  sonarqube_collector_version = "v0.2.0"
 }

--- a/tf/environments/aws/sandbox/terragrunt.hcl
+++ b/tf/environments/aws/sandbox/terragrunt.hcl
@@ -52,10 +52,10 @@ inputs = {
   update_coredns         = false
 
   rode_ui_version             = "v0.17.3"
-  rode_version                = "v0.14.4"
+  rode_version                = "v0.14.5"
   grafeas_version             = "v0.8.2"
   build_collector_version     = "v0.3.3"
   harbor_collector_version    = "v0.2.1"
   tfsec_collector_version     = "v0.1.1"
-  sonarqube_collector_version = "v0.2.0"
+  sonarqube_collector_version = "v0.2.1"
 }

--- a/tf/environments/local/terragrunt.hcl
+++ b/tf/environments/local/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   enable_keycloak = true
   keycloak_host   = "keycloak.localhost"
+  keycloak_tls_insecure_skip_verify = true
 
   tfsec_collector_host = "tfsec-collector.localhost"
   rode_ui_host         = "rode-ui.localhost"

--- a/tf/environments/local/terragrunt.hcl
+++ b/tf/environments/local/terragrunt.hcl
@@ -38,10 +38,10 @@ inputs = {
   ingress_name         = "nginx"
 
   rode_ui_version             = "v0.17.3"
-  rode_version                = "v0.14.4"
+  rode_version                = "v0.14.5"
   grafeas_version             = "v0.8.2"
   build_collector_version     = "v0.3.3"
   harbor_collector_version    = "v0.2.1"
   tfsec_collector_version     = "v0.1.1"
-  sonarqube_collector_version = "v0.2.0"
+  sonarqube_collector_version = "v0.2.1"
 }

--- a/tf/environments/local/terragrunt.hcl
+++ b/tf/environments/local/terragrunt.hcl
@@ -35,11 +35,11 @@ inputs = {
   rode_ui_host         = "rode-ui.localhost"
   ingress_name         = "nginx"
 
-  rode_ui_version             = "v0.12.0"
-  rode_version                = "v0.9.2"
+  rode_ui_version             = "v0.17.3"
+  rode_version                = "v0.14.4"
   grafeas_version             = "v0.8.2"
-  build_collector_version     = "v0.3.0"
-  harbor_collector_version    = "v0.1.0"
-  tfsec_collector_version     = "v0.1.0"
-  sonarqube_collector_version = "v0.1.0"
+  build_collector_version     = "v0.3.3"
+  harbor_collector_version    = "v0.2.1"
+  tfsec_collector_version     = "v0.1.1"
+  sonarqube_collector_version = "v0.2.0"
 }

--- a/tf/environments/local/terragrunt.hcl
+++ b/tf/environments/local/terragrunt.hcl
@@ -25,11 +25,12 @@ inputs = {
 
   enable_nginx = true
 
-  enable_sonarqube = true
-  sonarqube_host   = "sonarqube.localhost"
+  enable_sonarqube                   = true
+  sonarqube_host                     = "sonarqube.localhost"
+  sonarqube_tls_insecure_skip_verify = true
 
-  enable_keycloak = true
-  keycloak_host   = "keycloak.localhost"
+  enable_keycloak                   = true
+  keycloak_host                     = "keycloak.localhost"
   keycloak_tls_insecure_skip_verify = true
 
   tfsec_collector_host = "tfsec-collector.localhost"

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -106,9 +106,13 @@ module "rode" {
 
   oidc_auth_enabled = var.enable_keycloak
   oidc_issuer       = var.enable_keycloak ? module.keycloak[0].issuer_url : ""
+  oidc_token_url    = var.enable_keycloak ? module.keycloak[0].token_url : ""
 
   oidc_rode_client_id     = var.enable_keycloak ? module.keycloak[0].rode_client_id : ""
   oidc_rode_client_secret = var.enable_keycloak ? module.keycloak[0].rode_client_secret : ""
+
+  oidc_admin_username = var.enable_keycloak ? module.keycloak[0].admin_username : ""
+  oidc_admin_password = var.enable_keycloak ? module.keycloak[0].admin_password : ""
 
   depends_on = [
     module.grafeas

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -60,10 +60,11 @@ provider "keycloak" {
 }
 
 provider "sonarqube" {
-  host              = var.enable_sonarqube ? "https://${module.sonarqube[0].sonarqube_host}" : ""
-  user              = var.enable_sonarqube ? module.sonarqube[0].sonarqube_username : ""
-  pass              = var.enable_sonarqube ? module.sonarqube[0].sonarqube_password : ""
-  installed_version = "8.5"
+  host                     = var.enable_sonarqube ? "https://${module.sonarqube[0].sonarqube_host}" : ""
+  user                     = var.enable_sonarqube ? module.sonarqube[0].sonarqube_username : ""
+  pass                     = var.enable_sonarqube ? module.sonarqube[0].sonarqube_password : ""
+  installed_version        = "8.5"
+  tls_insecure_skip_verify = var.sonarqube_tls_insecure_skip_verify
 }
 
 module "elasticsearch" {

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -214,6 +214,10 @@ module "jenkins" {
   deploy_namespace      = var.deploy_namespace
   environments          = var.environments
 
+  oidc_client_id     = var.enable_keycloak ? module.keycloak[0].service_account_client_id["collector"] : ""
+  oidc_client_secret = var.enable_keycloak ? module.keycloak[0].service_account_client_secret["collector"] : ""
+  oidc_token_url     = var.enable_keycloak ? module.keycloak[0].token_url : ""
+
   depends_on = [
     module.nginx,
     module.harbor,

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -26,7 +26,7 @@ terraform {
 
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.2.0-rc.0"
+      version = "3.2.0"
     }
   }
 }
@@ -104,6 +104,12 @@ module "rode" {
   tfsec_collector_version = var.tfsec_collector_version
   ingress_class           = var.ingress_class
 
+  oidc_auth_enabled = var.enable_keycloak
+  oidc_issuer       = var.enable_keycloak ? module.keycloak[0].issuer_url : ""
+
+  oidc_rode_client_id     = var.enable_keycloak ? module.keycloak[0].rode_client_id : ""
+  oidc_rode_client_secret = var.enable_keycloak ? module.keycloak[0].rode_client_secret : ""
+
   depends_on = [
     module.grafeas
   ]
@@ -127,6 +133,11 @@ module "harbor" {
   harbor_insecure          = var.harbor_insecure
   harbor_collector_version = var.harbor_collector_version
   rode_host                = module.rode.rode_internal_host
+
+  oidc_auth_enabled  = var.enable_keycloak
+  oidc_client_id     = var.enable_keycloak ? module.keycloak[0].service_account_client_id["collector"] : ""
+  oidc_client_secret = var.enable_keycloak ? module.keycloak[0].service_account_client_secret["collector"] : ""
+  oidc_token_url     = var.enable_keycloak ? module.keycloak[0].token_url : ""
 
   depends_on = [
     module.nginx
@@ -169,6 +180,11 @@ module "sonarqube" {
   namespace_annotations       = var.namespace_annotations
   rode_host                   = module.rode.rode_internal_host
   sonarqube_collector_version = var.sonarqube_collector_version
+
+  oidc_auth_enabled  = var.enable_keycloak
+  oidc_client_id     = var.enable_keycloak ? module.keycloak[0].service_account_client_id["collector"] : ""
+  oidc_client_secret = var.enable_keycloak ? module.keycloak[0].service_account_client_secret["collector"] : ""
+  oidc_token_url     = var.enable_keycloak ? module.keycloak[0].token_url : ""
 }
 
 module "sonarqube_config" {

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -152,7 +152,11 @@ module "coredns" {
   count  = var.enable_nginx && var.update_coredns ? 1 : 0
   source = "../modules/coredns"
 
-  harbor_host       = var.harbor_host
+  rewrite_hosts = [
+    var.harbor_host,
+    var.keycloak_host,
+    var.sonarqube_host,
+  ]
   nginx_service_url = module.nginx[0].service_url
 
   depends_on = [

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -21,7 +21,7 @@ terraform {
     }
     sonarqube = {
       source  = "jdamata/sonarqube"
-      version = "0.0.5"
+      version = "0.0.7"
     }
 
     keycloak = {

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -8,7 +8,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "2.0.3"
+      version = "2.2.0"
     }
 
     random    = {
@@ -104,9 +104,10 @@ module "rode" {
   tfsec_collector_version = var.tfsec_collector_version
   ingress_class           = var.ingress_class
 
-  oidc_auth_enabled = var.enable_keycloak
-  oidc_issuer       = var.enable_keycloak ? module.keycloak[0].issuer_url : ""
-  oidc_token_url    = var.enable_keycloak ? module.keycloak[0].token_url : ""
+  oidc_auth_enabled             = var.enable_keycloak
+  oidc_issuer                   = var.enable_keycloak ? module.keycloak[0].issuer_url : ""
+  oidc_token_url                = var.enable_keycloak ? module.keycloak[0].token_url : ""
+  oidc_tls_insecure_skip_verify = var.keycloak_tls_insecure_skip_verify
 
   oidc_rode_client_id     = var.enable_keycloak ? module.keycloak[0].rode_client_id : ""
   oidc_rode_client_secret = var.enable_keycloak ? module.keycloak[0].rode_client_secret : ""
@@ -158,11 +159,6 @@ module "coredns" {
     var.sonarqube_host,
   ]
   nginx_service_url = module.nginx[0].service_url
-
-  depends_on = [
-    module.nginx,
-    module.harbor
-  ]
 }
 
 module "demo_app_setup" {
@@ -209,7 +205,7 @@ module "jenkins" {
   harbor_namespace      = module.harbor.namespace
   harbor_host           = var.harbor_host
   jenkins_host          = var.jenkins_host
-  sonarqube_host        = var.sonarqube_host
+  sonarqube_url         = var.enable_sonarqube ? "http://sonarqube-sonarqube.${var.sonarqube_namespace}.svc.cluster.local:9000" : ""
   sonarqube_token       = var.enable_sonarqube ? module.sonarqube_config[0].sonarqube_token : ""
   rode_namespace        = var.rode_namespace
   namespace             = var.jenkins_namespace

--- a/tf/k8s/variables.tf
+++ b/tf/k8s/variables.tf
@@ -84,6 +84,10 @@ variable "sonarqube_host" {}
 variable "sonarqube_namespace" {
   default = "rode-demo-sonarqube"
 }
+variable "sonarqube_tls_insecure_skip_verify" {
+  type    = bool
+  default = false
+}
 variable "sonarqube_collector_version" {
   default = ""
 }
@@ -94,7 +98,11 @@ variable "namespace_annotations" {
 
 variable "environments" {
   type    = set(string)
-  default = ["dev", "staging", "prod"]
+  default = [
+    "dev",
+    "staging",
+    "prod"
+  ]
 }
 
 variable "keycloak_host" {

--- a/tf/modules/coredns/main.tf
+++ b/tf/modules/coredns/main.tf
@@ -17,7 +17,7 @@ resource "kubernetes_config_map" "original_coredns" {
 }
 
 locals {
-  rewrite_line      = "rewrite name ${var.harbor_host} ${var.nginx_service_url}"
+  rewrite_line      = indent(4, join("\n", formatlist("rewrite name %s ${var.nginx_service_url}", compact(var.rewrite_hosts))))
   corefile_modified = <<EOF
 ${replace(kubernetes_config_map.original_coredns.data.Corefile, ".:53 {\n", ".:53 {\n    ${local.rewrite_line}\n")}
   EOF

--- a/tf/modules/coredns/variables.tf
+++ b/tf/modules/coredns/variables.tf
@@ -1,2 +1,5 @@
-variable "harbor_host" {}
+variable "rewrite_hosts" {
+  type = list(string)
+  default = []
+}
 variable "nginx_service_url" {}

--- a/tf/modules/demo-app-setup/app.tf
+++ b/tf/modules/demo-app-setup/app.tf
@@ -2,6 +2,9 @@ resource "kubernetes_namespace" "deploy_namespace" {
   for_each = var.environments
   metadata {
     name = "${var.deploy_namespace}-${each.key}"
+    labels = {
+      enforcer-k8s = "true"
+    }
   }
 }
 
@@ -21,10 +24,10 @@ resource "kubernetes_secret" "image_pull_secret" {
 
   type = "kubernetes.io/dockerconfigjson"
   data = {
-    ".dockerconfigjson" = templatefile("${path.module}/dockercfg.tpl", {
-      email = "admin@liatr.io"
-      url   = "https://${var.harbor_host}"
-      auth  = base64encode("admin:${data.kubernetes_secret.harbor.data.HARBOR_ADMIN_PASSWORD}")
+    ".dockerconfigjson" = templatefile("${path.module}/dockercfg-test.tpl", {
+      username = "admin"
+      password = data.kubernetes_secret.harbor.data.HARBOR_ADMIN_PASSWORD
+      url      = "https://${var.harbor_host}"
     })
   }
 }

--- a/tf/modules/demo-app-setup/app.tf
+++ b/tf/modules/demo-app-setup/app.tf
@@ -24,7 +24,7 @@ resource "kubernetes_secret" "image_pull_secret" {
 
   type = "kubernetes.io/dockerconfigjson"
   data = {
-    ".dockerconfigjson" = templatefile("${path.module}/dockercfg-test.tpl", {
+    ".dockerconfigjson" = templatefile("${path.module}/dockercfg.tpl", {
       username = "admin"
       password = data.kubernetes_secret.harbor.data.HARBOR_ADMIN_PASSWORD
       url      = "https://${var.harbor_host}"

--- a/tf/modules/demo-app-setup/dockercfg.tpl
+++ b/tf/modules/demo-app-setup/dockercfg.tpl
@@ -1,8 +1,8 @@
 {
   "auths": {
     "${url}": {
-      "email": "${email}",
-      "auth": "${auth}"
+      "username": "${username}",
+      "password": "${password}"
     }
   }
 }

--- a/tf/modules/elasticsearch/values.yaml.tpl
+++ b/tf/modules/elasticsearch/values.yaml.tpl
@@ -21,3 +21,8 @@ extraEnvs:
       secretKeyRef:
         name: ${elasticsearch_credentials_secret_name}
         key: password
+
+volumeClaimTemplate:
+  resources:
+    requests:
+      storage: 5Gi

--- a/tf/modules/harbor/main.tf
+++ b/tf/modules/harbor/main.tf
@@ -63,12 +63,17 @@ resource "helm_release" "rode_collector_harbor" {
   namespace  = kubernetes_namespace.harbor.metadata[0].name
   chart      = "rode-collector-harbor"
   repository = "https://rode.github.io/charts"
-  version    = "0.1.0"
+  version    = "0.2.0"
   wait       = true
 
   set_sensitive {
     name  = "harbor.password"
     value = random_password.harbor_admin_password.result
+  }
+
+  set_sensitive {
+    name  = "rode.auth.oidc.clientSecret"
+    value = var.oidc_client_secret
   }
 
   values = [
@@ -78,6 +83,10 @@ resource "helm_release" "rode_collector_harbor" {
       harbor_username          = "admin"
       harbor_insecure          = var.harbor_insecure
       harbor_collector_version = var.harbor_collector_version
+
+      oidc_auth_enabled = var.oidc_auth_enabled
+      oidc_client_id    = var.oidc_client_id
+      oidc_token_url    = var.oidc_token_url
     })
   ]
 }

--- a/tf/modules/harbor/rode-collector-harbor-values.yaml.tpl
+++ b/tf/modules/harbor/rode-collector-harbor-values.yaml.tpl
@@ -1,6 +1,13 @@
 rode:
   host: ${rode_host}
-  insecure: true
+
+  disableTransportSecurity: true
+
+  auth:
+    oidc:
+      enabled: ${oidc_auth_enabled}
+      clientId: ${oidc_client_id}
+      tokenUrl: ${oidc_token_url}
 
 harbor:
   host: ${harbor_url}

--- a/tf/modules/harbor/rode-collector-harbor-values.yaml.tpl
+++ b/tf/modules/harbor/rode-collector-harbor-values.yaml.tpl
@@ -8,6 +8,7 @@ rode:
       enabled: ${oidc_auth_enabled}
       clientId: ${oidc_client_id}
       tokenUrl: ${oidc_token_url}
+      tlsInsecureSkipVerify: true
 
 harbor:
   host: ${harbor_url}

--- a/tf/modules/harbor/variables.tf
+++ b/tf/modules/harbor/variables.tf
@@ -13,3 +13,21 @@ variable "harbor_collector_version" {
 }
 variable "harbor_insecure" {}
 variable "rode_host" {}
+
+variable "oidc_auth_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "oidc_client_id" {
+  type    = string
+  default = ""
+}
+variable "oidc_client_secret" {
+  type    = string
+  default = ""
+}
+variable "oidc_token_url" {
+  type    = string
+  default = ""
+}

--- a/tf/modules/jenkins/main.tf
+++ b/tf/modules/jenkins/main.tf
@@ -29,6 +29,23 @@ resource "kubernetes_secret" "jenkins_docker_config" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret" "jenkins_oidc_credentials" {
+  metadata {
+    name      = "jenkins-oidc-credentials"
+    namespace = kubernetes_namespace.jenkins.metadata[0].name
+  }
+
+  data = {
+    "credentials.json" = templatefile("${path.module}/oidc-credentials.tpl", {
+      oidc_token_url     = var.oidc_token_url
+      oidc_client_id     = var.oidc_client_id
+      oidc_client_secret = var.oidc_client_secret
+    })
+  }
+
+  type = "Opaque"
+}
+
 locals {
   jenkins_plugins = [
     "configuration-as-code",

--- a/tf/modules/jenkins/main.tf
+++ b/tf/modules/jenkins/main.tf
@@ -126,7 +126,7 @@ resource "kubernetes_config_map" "jcasc_pipelines" {
       pipelineRepo          = "demo-app"
       credentialsSecretName = ""
       harbor_host           = var.harbor_host
-      sonarqube_host        = var.sonarqube_host
+      sonarqube_url         = var.sonarqube_url
       sonarqube_credentials = kubernetes_secret.sonarcube_credentials.metadata[0].name
       rode_namespace        = var.rode_namespace
     })

--- a/tf/modules/jenkins/oidc-credentials.tpl
+++ b/tf/modules/jenkins/oidc-credentials.tpl
@@ -1,0 +1,5 @@
+{
+  "tokenUrl": "${oidc_token_url}",
+  "clientId": "${oidc_client_id}",
+  "clientSecret": "${oidc_client_secret}"
+}

--- a/tf/modules/jenkins/pipelines.yaml.tpl
+++ b/tf/modules/jenkins/pipelines.yaml.tpl
@@ -25,13 +25,13 @@ jobs:
         }
       }
 
-%{~ if sonarqube_host != "" }
+%{~ if sonarqube_url != "" }
 unclassified:
   sonarGlobalConfiguration:
     buildWrapperEnabled: false
     installations:
     - name: "SonarQube"
-      serverUrl: "https://${sonarqube_host}"
+      serverUrl: "${sonarqube_url}"
       credentialsId: "${sonarqube_credentials}"
 %{~ endif }
 

--- a/tf/modules/jenkins/values.yaml.tpl
+++ b/tf/modules/jenkins/values.yaml.tpl
@@ -15,3 +15,5 @@ rbac:
 serviceAccountAgent:
   name: jenkins-agent
 
+persistence:
+  size: 1Gi

--- a/tf/modules/jenkins/variables.tf
+++ b/tf/modules/jenkins/variables.tf
@@ -1,7 +1,7 @@
 variable "harbor_namespace" {}
 variable "harbor_host" {}
 variable "jenkins_host" {}
-variable "sonarqube_host" {
+variable "sonarqube_url" {
   default = ""
 }
 variable "sonarqube_token" {

--- a/tf/modules/jenkins/variables.tf
+++ b/tf/modules/jenkins/variables.tf
@@ -22,3 +22,16 @@ variable "environments" {
   type    = set(string)
   default = []
 }
+
+variable "oidc_client_id" {
+  type    = string
+  default = ""
+}
+variable "oidc_client_secret" {
+  type    = string
+  default = ""
+}
+variable "oidc_token_url" {
+  type    = string
+  default = ""
+}

--- a/tf/modules/keycloak/main.tf
+++ b/tf/modules/keycloak/main.tf
@@ -1,5 +1,8 @@
 locals {
-  rode_service_accounts = toset(["collector", "enforcer"])
+  rode_service_accounts = toset([
+    "collector",
+    "enforcer"
+  ])
 }
 
 resource "kubernetes_namespace" "keycloak" {
@@ -55,26 +58,34 @@ resource "helm_release" "keycloak" {
   }
 }
 
-resource "keycloak_realm" "rode_demo" {
-  realm   = "rode-demo"
-  enabled = true
+resource "time_sleep" "wait_for_keycloak" {
+  create_duration = "30s"
 
   depends_on = [
     helm_release.keycloak,
   ]
 }
 
+resource "keycloak_realm" "rode_demo" {
+  realm   = "rode-demo"
+  enabled = true
+
+  depends_on = [
+    time_sleep.wait_for_keycloak,
+  ]
+}
+
 resource "keycloak_openid_client" "rode" {
-  realm_id    = keycloak_realm.rode_demo.id
-  client_id   = "rode"
-  name        = "Rode"
-  access_type = "CONFIDENTIAL"
+  realm_id                     = keycloak_realm.rode_demo.id
+  client_id                    = "rode"
+  name                         = "Rode"
+  access_type                  = "CONFIDENTIAL"
   // Rode UI uses the authorization code flow
-  standard_flow_enabled = true
+  standard_flow_enabled        = true
   // password grant allows for easier local development and testing
   direct_access_grants_enabled = true
   enabled                      = true
-  valid_redirect_uris = [
+  valid_redirect_uris          = [
     "http://localhost:3000/",
     "http://localhost:3000/callback",
     "https://${var.rode_ui_host}/",

--- a/tf/modules/keycloak/main.tf
+++ b/tf/modules/keycloak/main.tf
@@ -59,7 +59,8 @@ resource "helm_release" "keycloak" {
 }
 
 resource "time_sleep" "wait_for_keycloak" {
-  create_duration = "30s"
+  create_duration  = "30s"
+  destroy_duration = "15s"
 
   depends_on = [
     helm_release.keycloak,

--- a/tf/modules/keycloak/outputs.tf
+++ b/tf/modules/keycloak/outputs.tf
@@ -5,3 +5,35 @@ output "keycloak_admin_password" {
     helm_release.keycloak
   ]
 }
+
+output "rode_client_id" {
+  value = keycloak_openid_client.rode.client_id
+}
+
+output "rode_client_secret" {
+  value = keycloak_openid_client.rode.client_secret
+
+  sensitive = true
+}
+
+output "service_account_client_id" {
+  value = tomap({
+    for s in local.rode_service_accounts : s => keycloak_openid_client.service_account[s].client_id
+  })
+}
+
+output "service_account_client_secret" {
+  value = tomap({
+    for s in local.rode_service_accounts : s => keycloak_openid_client.service_account[s].client_secret
+  })
+
+  sensitive = true
+}
+
+output "token_url" {
+  value = "https://${var.keycloak_host}/auth/realms/${keycloak_realm.rode_demo.realm}/protocol/openid-connect/token"
+}
+
+output "issuer_url" {
+  value = "https://${var.keycloak_host}/auth/realms/${keycloak_realm.rode_demo.realm}"
+}

--- a/tf/modules/keycloak/outputs.tf
+++ b/tf/modules/keycloak/outputs.tf
@@ -37,3 +37,11 @@ output "token_url" {
 output "issuer_url" {
   value = "https://${var.keycloak_host}/auth/realms/${keycloak_realm.rode_demo.realm}"
 }
+
+output "admin_username" {
+  value = keycloak_user.demo_user["Administrator"].username
+}
+
+output "admin_password" {
+  value = random_password.demo_user_password["Administrator"].result
+}

--- a/tf/modules/keycloak/values.tpl
+++ b/tf/modules/keycloak/values.tpl
@@ -58,6 +58,8 @@ postgresql:
     limits:
       memory: 128Mi
       cpu: 500m
+  persistence:
+    size: 1Gi
 
 startupProbe: ""
 

--- a/tf/modules/keycloak/values.tpl
+++ b/tf/modules/keycloak/values.tpl
@@ -65,5 +65,7 @@ livenessProbe: |
   httpGet:
     path: /auth/
     port: http
-  initialDelaySeconds: 120
+  initialDelaySeconds: 240
   timeoutSeconds: 5
+  periodSeconds: 10
+  failureThreshold: 2

--- a/tf/modules/keycloak/versions.tf
+++ b/tf/modules/keycloak/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.2.0-rc.0"
+      version = "3.2.0"
     }
   }
 }

--- a/tf/modules/nginx/values.yaml
+++ b/tf/modules/nginx/values.yaml
@@ -2,3 +2,5 @@ controller:
   kind: Deployment
   service:
     enabled: true
+  admissionWebhooks:
+    enabled: false

--- a/tf/modules/rode/loadpolicy.sh.tpl
+++ b/tf/modules/rode/loadpolicy.sh.tpl
@@ -1,8 +1,24 @@
 #!/bin/sh
-apk add curl
+apk add curl jq
+
+%{~ if oidc_auth_enabled == true }
+accessToken=$(
+    curl -s --fail \
+        -d "username=$${USERNAME}" \
+        -d "password=$${PASSWORD}" \
+        -d "client_id=$${CLIENT_ID}" \
+        -d "client_secret=$${CLIENT_SECRET}" \
+        -d "grant_type=password" \
+        "${oidc_token_url}" \
+    | jq -r '.access_token'
+)
+%{~ endif }
 
 %{ for policy in policies ~}
 curl -vvvvvL http://rode.${rode_namespace}.svc.cluster.local:50051/v1alpha1/policies \
-  --header 'Content-Type: application/json' \
+  %{~ if oidc_auth_enabled == true ~}
+  --header "Authorization: bearer $${accessToken}" \
+  %{~ endif ~}
+  --header "Content-Type: application/json" \
   --data '${jsonencode(policy)}'
 %{ endfor ~}

--- a/tf/modules/rode/loadpolicy.sh.tpl
+++ b/tf/modules/rode/loadpolicy.sh.tpl
@@ -1,9 +1,9 @@
 #!/bin/sh
 apk add curl jq
 
-%{~ if oidc_auth_enabled == true }
+%{~ if oidc_auth_enabled }
 accessToken=$(
-    curl -s --fail \
+    curl -s --fail -k \
         -d "username=$${USERNAME}" \
         -d "password=$${PASSWORD}" \
         -d "client_id=$${CLIENT_ID}" \
@@ -16,8 +16,8 @@ accessToken=$(
 
 %{ for policy in policies ~}
 curl -vvvvvL http://rode.${rode_namespace}.svc.cluster.local:50051/v1alpha1/policies \
-  %{~ if oidc_auth_enabled == true ~}
-  --header "Authorization: bearer $${accessToken}" \
+  %{~ if oidc_auth_enabled ~}
+  --header "Authorization: Bearer $${accessToken}" \
   %{~ endif ~}
   --header "Content-Type: application/json" \
   --data '${jsonencode(policy)}'

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -199,6 +199,7 @@ resource "helm_release" "rode_collector_build" {
     templatefile("${path.module}/rode-collector-build-values.yaml.tpl", {
       namespace               = kubernetes_namespace.rode.metadata[0].name
       build_collector_version = var.build_collector_version
+      oidc_auth_enabled       = var.oidc_auth_enabled
     })
   ]
 

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -176,9 +176,10 @@ resource "helm_release" "rode_ui" {
       rode_ui_host    = var.rode_ui_host
       ingress_class   = var.ingress_class
 
-      oidc_auth_enabled = var.oidc_auth_enabled
-      oidc_client_id    = var.oidc_rode_client_id
-      oidc_issuer       = var.oidc_issuer
+      oidc_auth_enabled             = var.oidc_auth_enabled
+      oidc_client_id                = var.oidc_rode_client_id
+      oidc_issuer                   = var.oidc_issuer
+      oidc_tls_insecure_skip_verify = var.oidc_tls_insecure_skip_verify
     })
   ]
 

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -192,7 +192,7 @@ resource "helm_release" "rode_collector_build" {
   namespace  = kubernetes_namespace.rode.metadata[0].name
   repository = "https://rode.github.io/charts"
   chart      = "rode-collector-build"
-  version    = "0.2.0"
+  version    = "0.3.0"
   wait       = true
 
   values = [

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -213,13 +213,14 @@ resource "helm_release" "rode_collector_tfsec" {
   namespace  = kubernetes_namespace.rode.metadata[0].name
   repository = "https://rode.github.io/charts"
   chart      = "rode-collector-tfsec"
-  version    = "0.1.0"
+  version    = "0.2.0"
   wait       = true
 
   values = [
     templatefile("${path.module}/rode-collector-tfsec-values.yaml.tpl", {
       namespace               = kubernetes_namespace.rode.metadata[0].name
       tfsec_collector_version = var.tfsec_collector_version
+      oidc_auth_enabled       = var.oidc_auth_enabled
     })
   ]
 

--- a/tf/modules/rode/main.tf
+++ b/tf/modules/rode/main.tf
@@ -19,7 +19,7 @@ resource "helm_release" "rode" {
   namespace  = kubernetes_namespace.rode.metadata[0].name
   chart      = "rode"
   repository = "https://rode.github.io/charts"
-  version    = "0.2.0"
+  version    = "0.3.0"
   wait       = true
 
   values = [
@@ -27,6 +27,11 @@ resource "helm_release" "rode" {
       grafeas_namespace  = var.grafeas_namespace
       elasticsearch_host = var.elasticsearch_host
       rode_version       = var.rode_version
+
+      oidc_auth_enabled           = var.oidc_auth_enabled
+      oidc_auth_issuer            = var.oidc_issuer
+      oidc_auth_required_audience = var.oidc_rode_client_id
+      oidc_auth_role_claim_path   = var.oidc_auth_enabled ? "resource_access.${var.oidc_rode_client_id}.roles" : ""
     })
   ]
 }
@@ -127,8 +132,13 @@ resource "helm_release" "rode_ui" {
   namespace  = kubernetes_namespace.rode.metadata[0].name
   chart      = "rode-ui"
   repository = "https://rode.github.io/charts"
-  version    = "0.2.0"
+  version    = "0.3.0"
   wait       = true
+
+  set_sensitive {
+    name  = "rode.auth.oidc.clientSecret"
+    value = var.oidc_rode_client_secret
+  }
 
   values = [
     templatefile("${path.module}/rode-ui-values.yaml.tpl", {
@@ -136,6 +146,10 @@ resource "helm_release" "rode_ui" {
       rode_ui_version = var.rode_ui_version
       rode_ui_host    = var.rode_ui_host
       ingress_class   = var.ingress_class
+
+      oidc_auth_enabled = var.oidc_auth_enabled
+      oidc_client_id    = var.oidc_rode_client_id
+      oidc_issuer       = var.oidc_issuer
     })
   ]
 

--- a/tf/modules/rode/rode-collector-build-values.yaml.tpl
+++ b/tf/modules/rode/rode-collector-build-values.yaml.tpl
@@ -1,6 +1,6 @@
 rode:
   host: rode.${namespace}.svc.cluster.local:50051
-  insecure: true
+  disableTransportSecurity: true
 
 debug: true
 

--- a/tf/modules/rode/rode-collector-build-values.yaml.tpl
+++ b/tf/modules/rode/rode-collector-build-values.yaml.tpl
@@ -2,6 +2,10 @@ rode:
   host: rode.${namespace}.svc.cluster.local:50051
   disableTransportSecurity: true
 
+  auth:
+    proxy:
+      enabled: ${oidc_auth_enabled}
+
 debug: true
 
 image:

--- a/tf/modules/rode/rode-collector-tfsec-values.yaml.tpl
+++ b/tf/modules/rode/rode-collector-tfsec-values.yaml.tpl
@@ -1,6 +1,10 @@
 rode:
   host: rode.${namespace}.svc.cluster.local:50051
-  insecure: true
+  disableTransportSecurity: true
+
+  auth:
+    proxy:
+      enabled: ${oidc_auth_enabled}
 
 debug: true
 

--- a/tf/modules/rode/rode-ui-values.yaml.tpl
+++ b/tf/modules/rode/rode-ui-values.yaml.tpl
@@ -7,6 +7,8 @@ rode:
       clientId: ${oidc_client_id}
       issuerUrl: ${oidc_issuer}
 
+appUrl: https://${rode_ui_host}
+
 image:
 %{~ if rode_ui_version != "" }
   tag: ${rode_ui_version}
@@ -15,10 +17,13 @@ image:
 ingress:
   enabled: true
   annotations:
+    %{~ if oidc_auth_enabled }
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    %{~ endif }
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-  %{~ if ingress_class != ""}
+  %{~ if ingress_class != "" }
     kubernetes.io/ingress.class: ${ingress_class}
-  %{~ endif}
+  %{~ endif }
   hosts:
     - host: ${rode_ui_host}
       paths:

--- a/tf/modules/rode/rode-ui-values.yaml.tpl
+++ b/tf/modules/rode/rode-ui-values.yaml.tpl
@@ -9,6 +9,12 @@ rode:
 
 appUrl: https://${rode_ui_host}
 
+%{~ if oidc_tls_insecure_skip_verify }
+extraEnvVars:
+  - name: NODE_TLS_REJECT_UNAUTHORIZED
+    value: "0"
+%{~ endif }
+
 image:
 %{~ if rode_ui_version != "" }
   tag: ${rode_ui_version}

--- a/tf/modules/rode/rode-ui-values.yaml.tpl
+++ b/tf/modules/rode/rode-ui-values.yaml.tpl
@@ -1,6 +1,12 @@
 rode:
   url: http://rode.${namespace}.svc.cluster.local:50051
 
+  auth:
+    oidc:
+      enabled: ${oidc_auth_enabled}
+      clientId: ${oidc_client_id}
+      issuerUrl: ${oidc_issuer}
+
 image:
 %{~ if rode_ui_version != "" }
   tag: ${rode_ui_version}

--- a/tf/modules/rode/rode-values.yaml.tpl
+++ b/tf/modules/rode/rode-values.yaml.tpl
@@ -16,3 +16,11 @@ image:
 %{~ if rode_version != "" }
   tag: "${rode_version}"
 %{~ endif }
+
+auth:
+  oidc:
+    enabled: ${oidc_auth_enabled}
+    issuer: ${oidc_auth_issuer}
+    requiredAudience: ${oidc_auth_required_audience}
+    roleClaimPath: ${oidc_auth_role_claim_path}
+    tlsInsecureSkipVerify: true

--- a/tf/modules/rode/variables.tf
+++ b/tf/modules/rode/variables.tf
@@ -69,3 +69,8 @@ variable "oidc_admin_password" {
   type    = string
   default = ""
 }
+
+variable "oidc_tls_insecure_skip_verify" {
+  type    = bool
+  default = false
+}

--- a/tf/modules/rode/variables.tf
+++ b/tf/modules/rode/variables.tf
@@ -41,15 +41,31 @@ variable "oidc_auth_enabled" {
 }
 
 variable "oidc_issuer" {
-  type = string
+  type    = string
+  default = ""
+}
+
+variable "oidc_token_url" {
+  type    = string
   default = ""
 }
 
 variable "oidc_rode_client_id" {
-  type = string
+  type    = string
   default = ""
 }
+
 variable "oidc_rode_client_secret" {
-  type = string
+  type    = string
+  default = ""
+}
+
+variable "oidc_admin_username" {
+  type    = string
+  default = ""
+}
+
+variable "oidc_admin_password" {
+  type    = string
   default = ""
 }

--- a/tf/modules/rode/variables.tf
+++ b/tf/modules/rode/variables.tf
@@ -34,3 +34,22 @@ variable "tfsec_collector_host" {
 variable "ingress_class" {
   default = ""
 }
+
+variable "oidc_auth_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "oidc_issuer" {
+  type = string
+  default = ""
+}
+
+variable "oidc_rode_client_id" {
+  type = string
+  default = ""
+}
+variable "oidc_rode_client_secret" {
+  type = string
+  default = ""
+}

--- a/tf/modules/sonarqube-config/versions.tf
+++ b/tf/modules/sonarqube-config/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     sonarqube = {
       source  = "jdamata/sonarqube"
-      version = "0.0.5"
+      version = "0.0.7"
     }
   }
 }

--- a/tf/modules/sonarqube/main.tf
+++ b/tf/modules/sonarqube/main.tf
@@ -46,16 +46,25 @@ resource "kubernetes_secret" "sonarqube_admin_password" {
 resource "helm_release" "rode_collector_sonarqube" {
   name       = "rode-collector-sonarqube"
   namespace  = kubernetes_namespace.sonarqube.metadata[0].name
-  chart      = "rode-collector-sonarqube"
-  repository = "https://rode.github.io/charts"
-  version    = "0.0.1"
+  chart      = "/Users/parker/Developer/rode-charts/charts/rode-collector-sonarqube"
+#  repository = "https://rode.github.io/charts"
+  version    = "0.1.0"
   wait       = true
+
+  set_sensitive {
+    name  = "rode.auth.oidc.clientSecret"
+    value = var.oidc_client_secret
+  }
 
   values = [
     templatefile("${path.module}/rode-collector-sonarqube-values.yaml.tpl", {
       namespace                   = kubernetes_namespace.sonarqube.metadata[0].name
       sonarqube_collector_version = var.sonarqube_collector_version
       rode_host                   = var.rode_host
+
+      oidc_auth_enabled = var.oidc_auth_enabled
+      oidc_client_id    = var.oidc_client_id
+      oidc_token_url    = var.oidc_token_url
     })
   ]
 }

--- a/tf/modules/sonarqube/main.tf
+++ b/tf/modules/sonarqube/main.tf
@@ -46,8 +46,8 @@ resource "kubernetes_secret" "sonarqube_admin_password" {
 resource "helm_release" "rode_collector_sonarqube" {
   name       = "rode-collector-sonarqube"
   namespace  = kubernetes_namespace.sonarqube.metadata[0].name
-  chart      = "/Users/parker/Developer/rode-charts/charts/rode-collector-sonarqube"
-#  repository = "https://rode.github.io/charts"
+  chart      = "rode-collector-sonarqube"
+  repository = "https://rode.github.io/charts"
   version    = "0.1.0"
   wait       = true
 

--- a/tf/modules/sonarqube/rode-collector-sonarqube-values.yaml.tpl
+++ b/tf/modules/sonarqube/rode-collector-sonarqube-values.yaml.tpl
@@ -1,6 +1,13 @@
 rode:
   host: ${rode_host}
-  insecure: true
+
+  disableTransportSecurity: true
+
+  auth:
+    oidc:
+      enabled: ${oidc_auth_enabled}
+      clientId: ${oidc_client_id}
+      tokenUrl: ${oidc_token_url}
 
 debug: true
 

--- a/tf/modules/sonarqube/rode-collector-sonarqube-values.yaml.tpl
+++ b/tf/modules/sonarqube/rode-collector-sonarqube-values.yaml.tpl
@@ -8,6 +8,7 @@ rode:
       enabled: ${oidc_auth_enabled}
       clientId: ${oidc_client_id}
       tokenUrl: ${oidc_token_url}
+      tlsInsecureSkipVerify: true
 
 debug: true
 

--- a/tf/modules/sonarqube/values.yaml.tpl
+++ b/tf/modules/sonarqube/values.yaml.tpl
@@ -16,3 +16,14 @@ ingress:
 sonarProperties:
   "sonar.core.serverBaseURL": "https://${host}"
   "sonar.log.level": "DEBUG"
+
+postgresql:
+  resources:
+    requests:
+      memory: 64Mi
+      cpu: 10m
+    limits:
+      memory: 128Mi
+      cpu: 500m
+  persistence:
+    size: 1Gi

--- a/tf/modules/sonarqube/values.yaml.tpl
+++ b/tf/modules/sonarqube/values.yaml.tpl
@@ -15,3 +15,4 @@ ingress:
 
 sonarProperties:
   "sonar.core.serverBaseURL": "https://${host}"
+  "sonar.log.level": "DEBUG"

--- a/tf/modules/sonarqube/variables.tf
+++ b/tf/modules/sonarqube/variables.tf
@@ -11,3 +11,21 @@ variable "rode_host" {}
 variable "sonarqube_collector_version" {
   default = ""
 }
+
+variable "oidc_auth_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "oidc_client_id" {
+  type    = string
+  default = ""
+}
+variable "oidc_client_secret" {
+  type    = string
+  default = ""
+}
+variable "oidc_token_url" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
oidc configuration is exported from the `keycloak` module and fed into the other modules that deploy rode / UI / collectors.  jenkins has been updated to add a secret credential that can be consumed by jobs to make authenticated calls to the build collector.

depends on https://github.com/rode/charts/pull/81