### PR TITLE
Update Rode UI and tfsec-collector versions

### DIFF
--- a/tf/environments/aws/prod/terragrunt.hcl
+++ b/tf/environments/aws/prod/terragrunt.hcl
@@ -51,12 +51,12 @@ inputs = {
   tfsec_collector_host   = "tfsec-collector.rode.lead.prod.liatr.io"
   update_coredns         = false
 
-  rode_ui_version             = "v0.17.3"
+  rode_ui_version             = "v0.17.4"
   rode_version                = "v0.14.5"
   grafeas_version             = "v0.8.2"
   build_collector_version     = "v0.3.3"
   harbor_collector_version    = "v0.2.2"
-  tfsec_collector_version     = "v0.1.1"
+  tfsec_collector_version     = "v0.1.2"
   sonarqube_collector_version = "v0.2.1"
 
   namespace_annotations = {

--- a/tf/environments/aws/sandbox/terragrunt.hcl
+++ b/tf/environments/aws/sandbox/terragrunt.hcl
@@ -51,11 +51,11 @@ inputs = {
   tfsec_collector_host   = "tfsec-collector.rode.lead.sandbox.liatr.io"
   update_coredns         = false
 
-  rode_ui_version             = "v0.17.3"
+  rode_ui_version             = "v0.17.4"
   rode_version                = "v0.14.5"
   grafeas_version             = "v0.8.2"
   build_collector_version     = "v0.3.3"
   harbor_collector_version    = "v0.2.2"
-  tfsec_collector_version     = "v0.1.1"
+  tfsec_collector_version     = "v0.1.2"
   sonarqube_collector_version = "v0.2.1"
 }

--- a/tf/environments/local/terragrunt.hcl
+++ b/tf/environments/local/terragrunt.hcl
@@ -37,11 +37,11 @@ inputs = {
   rode_ui_host         = "rode-ui.localhost"
   ingress_name         = "nginx"
 
-  rode_ui_version             = "v0.17.3"
+  rode_ui_version             = "v0.17.4"
   rode_version                = "v0.14.5"
   grafeas_version             = "v0.8.2"
   build_collector_version     = "v0.3.3"
   harbor_collector_version    = "v0.2.2"
-  tfsec_collector_version     = "v0.1.1"
+  tfsec_collector_version     = "v0.1.2"
   sonarqube_collector_version = "v0.2.1"
 }

--- a/tf/k8s/main.tf
+++ b/tf/k8s/main.tf
@@ -244,4 +244,8 @@ module "keycloak" {
   ingress_class         = var.ingress_class
   keycloak_host         = var.keycloak_host
   rode_ui_host          = var.rode_ui_host
+
+  depends_on = [
+    module.nginx,
+  ]
 }


### PR DESCRIPTION
Brings in these changes:
https://github.com/rode/rode-ui/pull/164
https://github.com/rode/collector-tfsec/pull/6

Also fixes an issue where Terraform may try to create/destroy Keycloak resources without nginx available. 